### PR TITLE
feat: switch TLV encoding from self-delimiting to LEB128 length-prefixed

### DIFF
--- a/arkade-assets.md
+++ b/arkade-assets.md
@@ -109,7 +109,7 @@ scriptPubKey = OP_RETURN <Magic_Bytes> <TLV_Stream>
   - Unknown types: parsers MUST skip `Length` bytes to reach the next record.
   - Duplicate types within a single extension are rejected.
 
-**Multiple OP_RETURN Handling:** If a transaction contains multiple OP_RETURN outputs with ARK magic bytes (`0x41524b`), or multiple Type `0x00` (Assets) records across TLV streams, only the **first Type `0x00` record found by output index order** is processed. Subsequent Asset records are ignored.
+**Multiple OP_RETURN Handling:** If a transaction contains multiple OP_RETURN outputs with ARK magic bytes (`0x41524b`), or multiple Type `0x00` (Assets) records across TLV streams, it is rejected.
 
 ### Arkade Asset V1 Packet (Type 0x00)
 

--- a/arkade-assets.md
+++ b/arkade-assets.md
@@ -105,7 +105,7 @@ scriptPubKey = OP_RETURN <Magic_Bytes> <TLV_Stream>
 - **TLV_Stream**: A concatenation of one or more TLV records.
 - **TLV Record**: `Type(1 byte) || Length(LEB128 varint) || Payload`
   - All packet types use explicit LEB128 varint length framing.
-  - Known types: `0x00` = Arkade Asset, `0x01` = Introspector (reserved).
+  - Known types: `0x00` = Arkade Asset
   - Unknown types: parsers MUST skip `Length` bytes to reach the next record.
   - Duplicate types within a single extension are rejected.
 

--- a/arkade-assets.md
+++ b/arkade-assets.md
@@ -103,22 +103,23 @@ scriptPubKey = OP_RETURN <Magic_Bytes> <TLV_Stream>
 
 - **Magic_Bytes**: `0x41524b` ("ARK")
 - **TLV_Stream**: A concatenation of one or more TLV records.
-- **TLV Record**: Format determined by type byte range:
-  - `0x00-0x3F`: Self-delimiting types. `Type || Payload` (no length field)
-  - `0x40-0x7F`: Variable-length spec types. `Type || Length (varint) || Payload`
-  - `0x80-0xFF`: Extensions. `Type || Length (varint) || Payload` (parsers can skip unknown)
+- **TLV Record**: `Type(1 byte) || Length(LEB128 varint) || Payload`
+  - All packet types use explicit LEB128 varint length framing.
+  - Known types: `0x00` = Arkade Asset, `0x01` = Introspector (reserved).
+  - Unknown types: parsers MUST skip `Length` bytes to reach the next record.
+  - Duplicate types within a single extension are rejected.
 
 **Multiple OP_RETURN Handling:** If a transaction contains multiple OP_RETURN outputs with ARK magic bytes (`0x41524b`), or multiple Type `0x00` (Assets) records across TLV streams, only the **first Type `0x00` record found by output index order** is processed. Subsequent Asset records are ignored.
 
 ### Arkade Asset V1 Packet (Type 0x00)
 
-The Arkade Asset data is identified by `Type = 0x00`. As a self-delimiting type (range 0x00-0x3F), no length field is needed.
+The Arkade Asset data is identified by `Type = 0x00`. The length of the asset payload is encoded as a LEB128 varint.
 
 ```
-<Type: 0x00> <Asset_Payload>
+<Type: 0x00> <Length: LEB128 varint> <Asset_Payload>
 ```
 
-- **Asset_Payload**: The TLV packet containing asset group data (see below).
+- **Asset_Payload**: The binary-encoded asset group data (see below).
 
 **Note (Implicit Burn Policy):** If a transaction spends any UTXOs known to carry Arkade Asset balances but contains no `OP_RETURN` with an Arkade Asset packet (Type `0x00`), those balances are considered irrecoverably burned. Indexers MUST remove such balances from their state.
 
@@ -218,10 +219,13 @@ AssetOutput := { vout: u16 LE, amount: varint }   # output within same transacti
 For implementers, here is the complete binary format:
 
 ```
-# OP_RETURN Structure
-OP_RETURN := "ARK" || AssetMarker || Packet
+# OP_RETURN Structure (Extension TLV)
+OP_RETURN := "ARK" || TLV_Record...
 
-AssetMarker := 0x00  # Identifier for op_ret asset data
+TLV_Record := Type(1 byte) || Length(LEB128 varint) || Payload
+
+# Asset TLV Record (Type 0x00)
+AssetRecord := 0x00 || LEB128(len(Packet)) || Packet
 
 # Asset Packet
 Packet := {

--- a/tools/arkade-assets-codec.test.ts
+++ b/tools/arkade-assets-codec.test.ts
@@ -1038,11 +1038,11 @@ function testLittleEndianIndexEncoding() {
   console.log('  ✓ Little-endian index encoding passed');
 }
 
-function testSelfDelimitingTlv() {
-  console.log('Testing self-delimiting TLV encoding...');
+function testLengthPrefixedTlv() {
+  console.log('Testing LEB128 length-prefixed TLV encoding...');
 
-  // Build a minimal packet and check that the payload uses self-delimiting type 0x00
-  // (no length field), saving 1 byte compared to a length-prefixed TLV.
+  // Build a minimal packet and check that the payload uses type 0x00 with
+  // LEB128 varint length prefix (matching arkd PR #946).
   const packet: Packet = {
     groups: [{
       issuance: { metadata: { name: 'TLV' } },
@@ -1053,46 +1053,33 @@ function testSelfDelimitingTlv() {
 
   const payload = buildOpReturnPayload(packet);
 
-  // Payload format: magic(3) + type(1) + asset_data(variable)
+  // Payload format: magic(3) + type(1) + leb128_length + asset_data(variable)
   // magic = "ARK" = 0x41 0x52 0x4b
   assert.strictEqual(payload[0], 0x41, 'Magic byte 0 should be "A"');
   assert.strictEqual(payload[1], 0x52, 'Magic byte 1 should be "R"');
   assert.strictEqual(payload[2], 0x4b, 'Magic byte 2 should be "K"');
   assert.strictEqual(payload[3], 0x00, 'TLV type should be 0x00');
 
-  // Verify there is NO length field after the type byte.
-  // In self-delimiting format, byte 4 should be the start of the asset payload
-  // (i.e., the group count varint), NOT a length prefix.
-  // A packet with 1 group would have group count = 1 (varint: 0x01).
-  assert.strictEqual(payload[4], 0x01, 'Byte after type should be group count (1), not a length prefix');
+  // Verify there IS a LEB128 length field after the type byte.
+  // Byte 4 should be the LEB128-encoded length of the asset data.
+  // The asset data length should be small enough to fit in one LEB128 byte (<128).
+  const assetDataLength = payload.length - 5; // everything after magic + type + 1-byte length
+  assert.ok(assetDataLength > 0 && assetDataLength < 128,
+    'Asset data should be small enough for 1-byte LEB128');
+  assert.strictEqual(payload[4], assetDataLength,
+    'Byte after type should be LEB128 length of asset data');
+
+  // Byte 5 should be the start of the asset payload (group count = 1).
+  assert.strictEqual(payload[5], 0x01, 'First data byte should be group count (1)');
 
   // Verify the round-trip works correctly
   const script = buildOpReturnScript(packet);
   const decoded = parseOpReturnScript(script);
-  assert.ok(decoded, 'Self-delimiting TLV should decode correctly');
+  assert.ok(decoded, 'Length-prefixed TLV should decode correctly');
   assert.strictEqual(decoded.groups?.length, 1, 'Should have 1 group');
   assert.strictEqual(decoded.groups?.[0].outputs[0].amt, '1', 'Amount should round-trip');
 
-  // Verify payload is 1 byte shorter than it would be with a length field.
-  // With a length field, the format would be: magic(3) + type(1) + compactsize_length + data
-  // Without: magic(3) + type(1) + data
-  // The data portion starts at offset 4 in the self-delimiting format.
-  const assetDataLength = payload.length - 4; // everything after magic + type byte
-  // If we had a length prefix, for small payloads (<253 bytes) it would add 1 byte
-  // So the self-delimiting format saves exactly 1 byte for small payloads.
-  assert.ok(assetDataLength < 253, 'Asset data should be small enough that length prefix would be 1 byte');
-  // The total payload with length-prefix would be: 3(magic) + 1(type) + 1(length) + assetDataLength
-  // Self-delimiting:                               3(magic) + 1(type) + assetDataLength
-  // Difference = 1 byte saved
-  const expectedWithLengthPrefix = 3 + 1 + 1 + assetDataLength;
-  const actualSelfDelimiting = payload.length;
-  assert.strictEqual(
-    expectedWithLengthPrefix - actualSelfDelimiting,
-    1,
-    `Self-delimiting should save exactly 1 byte (expected ${expectedWithLengthPrefix} with length, got ${actualSelfDelimiting} without)`
-  );
-
-  console.log('  ✓ Self-delimiting TLV encoding passed');
+  console.log('  ✓ LEB128 length-prefixed TLV encoding passed');
 }
 
 // ----------------- REORG TESTS -----------------
@@ -1575,7 +1562,7 @@ async function runAllTests() {
     // Compact encoding edge case tests
     testVarintAmountBoundaries();
     testLittleEndianIndexEncoding();
-    testSelfDelimitingTlv();
+    testLengthPrefixedTlv();
 
     // Taproot-aligned merkle tree tests
     testTaggedHashDomainSeparation();

--- a/tools/arkade-assets-codec.ts
+++ b/tools/arkade-assets-codec.ts
@@ -270,11 +270,42 @@ function decodeVarUint(buf: Uint8Array, off: number): { value: number; size: num
   return decodeCompactSize(buf, off);
 }
 
+// --- LEB128 varint encoding (used for TLV length framing, matching arkd's binary.ReadUvarint) ---
+
+function encodeLeb128(n: number): Uint8Array {
+  if (n < 0) throw new Error('LEB128 value must be >= 0');
+  const bytes: number[] = [];
+  do {
+    let byte = n & 0x7f;
+    n >>>= 7;
+    if (n !== 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (n !== 0);
+  return new Uint8Array(bytes);
+}
+
+function decodeLeb128(buf: Uint8Array, off: number): { value: number; size: number } {
+  let value = 0;
+  let shift = 0;
+  let i = off;
+  while (i < buf.length) {
+    const byte = buf[i];
+    value |= (byte & 0x7f) << shift;
+    i++;
+    if ((byte & 0x80) === 0) {
+      return { value, size: i - off };
+    }
+    shift += 7;
+    if (shift > 35) throw new Error('LEB128 value too large');
+  }
+  throw new Error('LEB128 truncated');
+}
+
 function encodeTlv(type: number, value: Uint8Array): Uint8Array {
   if (type > 255 || type < 0) throw new Error('TLV type must be a byte');
   return concatBytes(
     new Uint8Array([type]),
-    encodeCompactSize(value.length),
+    encodeLeb128(value.length),
     value
   );
 }
@@ -425,8 +456,8 @@ export function encodePacket(packet: Packet): Uint8Array {
 export function buildOpReturnPayload(packet: Packet): Uint8Array {
   const magic = hexToBytes('41524b'); // "ARK"
   const assetPayload = encodePacket(packet);
-  // Type 0x00 is self-delimiting (no length field)
-  return concatBytes(magic, new Uint8Array([0x00]), assetPayload);
+  // Type 0x00 with LEB128 varint length prefix (matching arkd PR #946)
+  return concatBytes(magic, encodeTlv(0x00, assetPayload));
 }
 
 export function buildOpReturnScript(packet: Packet): Uint8Array {
@@ -442,19 +473,12 @@ function decodeTlvStream(buf: Uint8Array, off: number): { records: { type: numbe
   while (cursor < buf.length) {
     const type = buf[cursor];
     cursor += 1;
-    if (type <= 0x3f) {
-      // Self-delimiting: rest of buffer is the payload
-      const value = buf.slice(cursor);
-      cursor = buf.length;
-      records.push({ type, value });
-    } else {
-      // 0x40-0xFF: length-prefixed
-      const lenResult = decodeCompactSize(buf, cursor);
-      cursor += lenResult.size;
-      const value = buf.slice(cursor, cursor + lenResult.value);
-      cursor += lenResult.value;
-      records.push({ type, value });
-    }
+    // All types use LEB128 varint length prefix (matching arkd PR #946)
+    const lenResult = decodeLeb128(buf, cursor);
+    cursor += lenResult.size;
+    const value = buf.slice(cursor, cursor + lenResult.value);
+    cursor += lenResult.value;
+    records.push({ type, value });
   }
   return { records, next: cursor };
 }


### PR DESCRIPTION
## Summary

Align with [arkd PR #946](https://github.com/arkade-os/arkd/pull/946) ("encode packet with TLV") extension encoding format.

- **All TLV record types now use LEB128 varint length prefix** — previously types `0x00-0x3F` were self-delimiting (consumed the rest of the buffer with no length field). Now every type uses `Type(1B) || LEB128(len) || Data`.
- **Added `encodeLeb128`/`decodeLeb128` functions** for TLV envelope framing (internal to codec, not exported). These match Go's `binary.ReadUvarint`/`binary.PutUvarint`.
- **Updated `buildOpReturnPayload`** to emit `type + leb128(len) + data` instead of `type + data`.
- **Updated `decodeTlvStream`** to read LEB128 length for all types (removed self-delimiting branch).
- **Updated spec doc** (`arkade-assets.md`) to describe the new TLV record format.
- **Updated test** from `testSelfDelimitingTlv` to `testLengthPrefixedTlv`.

This enables multiple co-existing packet types (assets=0x00, introspector=0x01, future types) with explicit framing so parsers can skip unknown types.

Companion PRs:
- dotnet-sdk: https://github.com/arkade-os/dotnet-sdk/pull/28
- arkd: https://github.com/arkade-os/arkd/pull/946

## Test plan

- [x] All codec tests pass (`npx tsx tools/arkade-assets-codec.test.ts`)
- [x] Round-trip encoding/decoding verified with LEB128 length prefix